### PR TITLE
Reduce Ethereum guardian node balance requirement

### DIFF
--- a/src/configs.ts
+++ b/src/configs.ts
@@ -24,6 +24,7 @@ interface IContaractAdresses {
 export interface INetwork {
   name: string;
   logo?: string;
+  minimumNodeBalance: string;
   requiredConfirmations?: number;
   nativeCurrency?: { name: string; symbol: string; decimals: number };
   rpcUrls?: string[];
@@ -38,6 +39,7 @@ export const REQUIRED_CHAINS = [1, 3]
 const networks: { [key: string]: INetwork } = {
   "1": {
     name: "Ethereum",
+    minimumNodeBalance: "0.1",
     logo: ethImg,
     nav: ethereumNavImg,
     nativeCurrency: { name: "ETH", symbol: "ETH", decimals: 18 },
@@ -48,6 +50,7 @@ const networks: { [key: string]: INetwork } = {
   },
   "3": {
     name: "Ropsten",
+    minimumNodeBalance: "1",
     logo: ethImg,
     nav: ethereumNavImg,
     nativeCurrency: { name: "ETH", symbol: "ETH", decimals: 18 },
@@ -59,9 +62,10 @@ const networks: { [key: string]: INetwork } = {
   "137": {
     color: "#844FDA",
     name: "Polygon",
+    minimumNodeBalance: "1",
     logo: polygonImg,
     nav: polygonNavImg,
-    nativeCurrency: { name: "MATIC", symbol: "MATIC", decimals: 18 },
+    nativeCurrency: { name: "POL", symbol: "POL", decimals: 18 },
     rpcUrls: ["https://rpcman.orbs.network/rpc?chainId=137&appId=guardian-registration&key=943b6d32040df8de03ff37b6ed4125cd98fee2ac"],
     blockExplorerUrls: ["https://www.polygonscan.com"],
     contractsRegistry: "0x35eA0D75b2a3aB06393749B4651DfAD1Ffd49A77",

--- a/src/pages/GuardianFormDetailsList.tsx
+++ b/src/pages/GuardianFormDetailsList.tsx
@@ -88,10 +88,9 @@ export const useNodeAddressDetailsTexts = () => {
         );
     }, [explanationTextsTranslations, theme.palette.secondary.main]);
   const chain = useNetwork();
-  const symbol = chain &&
-  configs.networks[chain] &&
-  chain &&
-  configs.networks[chain].nativeCurrency?.symbol
+  const symbol = chain && configs.networks[chain]?.nativeCurrency?.symbol;
+  const minimumNodeBalance =
+    chain && configs.networks[chain]?.minimumNodeBalance;
   const nodeAddressExplainingTexts = useMemo<
     Array<string | TInnerHtmlFunction>
   >(() => {
@@ -100,16 +99,22 @@ export const useNodeAddressDetailsTexts = () => {
       explanationTextsTranslations("text_nodeAddress_usedToSignBlocks"),
       explanationTextsTranslations(
         "text_nodeAddress_holdsEthForAutomatedTransactionsGas",
-        { symbol}
+        { symbol }
       ),
       explanationTextsTranslations("text_nodeAddress_minimalBalanceRequired", {
-        symbol
+        balance: minimumNodeBalance,
+        symbol,
       }),
       explanationTextsTranslations("text_nodeAddress_doesNotHoldYourTokens"),
     ];
 
     return texts;
-  }, [explainingTextOfShouldBeDifferentInnerHtml, explanationTextsTranslations, symbol]);
+  }, [
+    explainingTextOfShouldBeDifferentInnerHtml,
+    explanationTextsTranslations,
+    minimumNodeBalance,
+    symbol,
+  ]);
 
   return {
     texts: nodeAddressExplainingTexts,

--- a/src/pages/GuardiandRegisterOrEdit/guardianRegister/RegisterGuardianSection.tsx
+++ b/src/pages/GuardiandRegisterOrEdit/guardianRegister/RegisterGuardianSection.tsx
@@ -19,6 +19,8 @@ import { MobXProviderContext } from "mobx-react";
 import { getChainName, getChainNames, getOptionalChainName, getRequiredChainName } from "../../../utils/chain";
 import { ActionConfirmationModal } from "../../../components/shared/modals/ActionConfirmationModal";
 import { useOrbsAccountStore } from "../../../store/storeHooks";
+import Web3 from "web3";
+import configs from "../../../configs";
 
 interface IProps {
   guardianAddress: string;
@@ -56,18 +58,17 @@ const emptyInitialInfo: TGuardianInfo = {
   name: "",
 };
 
-const MINIMAL_REQUIRED_ETH_BALANCE = 1;
-
 export const RegisterGuardianSection = React.memo<IProps>((props) => {
   const classes = useStyles();
-  const { guardianAddress, registerGuardian, cryptoWalletConnectionService } =
-    props;
+  const { guardianAddress, registerGuardian } = props;
 
   const guardianDataFormsTranslations = useGuardianDataFormsTranslations();
   const domainTranslations = useDomainTranslations();
   const registerGuardianSectionTranslations =
     useRegisterGuardianSectionTranslations();
   const { chainId } = useContext(MobXProviderContext);
+  const minimumNodeBalance =
+    configs.networks[chainId]?.minimumNodeBalance || "1";
   const [errorMessage, setErrorMessage] = useState<string | undefined>(
     undefined
   );
@@ -93,16 +94,26 @@ export const RegisterGuardianSection = React.memo<IProps>((props) => {
         return;
       }
 
-      const orbsNodeBalance =
-        await cryptoWalletConnectionService.readEthereumBalance(
-          guardianRegistrationPayload.orbsAddr
+      const web3 = new Web3(Web3.givenProvider);
+      const orbsNodeBalanceInWei = await web3.eth.getBalance(
+        guardianRegistrationPayload.orbsAddr
+      );
+      const hasInsufficientBalance = web3.utils
+        .toBN(orbsNodeBalanceInWei)
+        .lt(
+          web3.utils.toBN(
+            web3.utils.toWei(minimumNodeBalance, "ether")
+          )
         );
 
-      if (orbsNodeBalance < MINIMAL_REQUIRED_ETH_BALANCE) {
+      if (hasInsufficientBalance) {
         setErrorMessage(
           registerGuardianSectionTranslations(
             "error_minimalBalanceAtNodeAddressIsRequired",
-            { name: getChainName(chainId) }
+            {
+              balance: minimumNodeBalance,
+              name: getChainName(chainId),
+            }
           )
         );
         return;
@@ -118,10 +129,10 @@ export const RegisterGuardianSection = React.memo<IProps>((props) => {
       }
     },
     [
-      cryptoWalletConnectionService,
       guardianAddress,
       registerGuardianSectionTranslations,
       chainId,
+      minimumNodeBalance,
       orbsAccountStore.unregisteredChains.length,
       registerGuardian,
     ]

--- a/src/translations/locales/en/explanationsTexts.json
+++ b/src/translations/locales/en/explanationsTexts.json
@@ -7,7 +7,7 @@
   "text_guardianAddress_usedByDelegatorsToDelegate": "Used by Delegators to delegate to the Guardian",
   "text_nodeAddress_doesNotHoldYourTokens": "Does NOT hold your Guardian ORBS tokens",
   "text_nodeAddress_holdsEthForAutomatedTransactionsGas": "Holds {{symbol}} for node automated transactions gas",
-  "text_nodeAddress_minimalBalanceRequired": "A minimal balance of 1 {{symbol}} is required upon registration",
+  "text_nodeAddress_minimalBalanceRequired": "A minimal balance of {{balance}} {{symbol}} is required upon registration",
   "text_nodeAddress_shouldBeDifferentFromGuardianAddress": "Should be different from the {{conceptNameGuardianAddress}}",
   "text_nodeAddress_usedToSignBlocks": "Used by the node to sign blocks on Orbs blockchain"
 }

--- a/src/translations/locales/en/registerGuardianSection.json
+++ b/src/translations/locales/en/registerGuardianSection.json
@@ -1,6 +1,6 @@
 {
   "action_register": "register",
-  "error_minimalBalanceAtNodeAddressIsRequired": "A minimal balance of 1 {{name}} at the 'Node Address' is required in order to register as a guardian.",
+  "error_minimalBalanceAtNodeAddressIsRequired": "A minimal balance of {{balance}} {{name}} at the 'Node Address' is required in order to register as a guardian.",
   "error_nodeAddressCannotBeTheSameAsGuardianAddress": "Your Orbs node address cannot be the same as your Guardian address {{guardianAddress}}",
   "text_pleaseNote": "Please Notice",
   "title_guardianRegistration": "Guardian Registration",

--- a/src/translations/locales/ja/explanationsTexts.json
+++ b/src/translations/locales/ja/explanationsTexts.json
@@ -7,7 +7,7 @@
   "text_guardianAddress_usedByDelegatorsToDelegate": "デリゲータがガーディアンに委任するために使用します",
   "text_nodeAddress_doesNotHoldYourTokens": "ガーディアンORBSトークンを持っていません。",
   "text_nodeAddress_holdsEthForAutomatedTransactionsGas": "ノードの自動トランザクションのため{{symbol}}のガス利用料を保有ください",
-  "text_nodeAddress_minimalBalanceRequired": "登録時に最低1{{symbol}}の残高が必要です",
+  "text_nodeAddress_minimalBalanceRequired": "登録時に最低{{balance}} {{symbol}}の残高が必要です",
   "text_nodeAddress_shouldBeDifferentFromGuardianAddress": "{{conceptNameGuardianAddress}}とは別である必要があります",
   "text_nodeAddress_usedToSignBlocks": "Orbsブロックチェーンにブロックを署名するためにノードによって使用されます"
 }

--- a/src/translations/locales/ja/registerGuardianSection.json
+++ b/src/translations/locales/ja/registerGuardianSection.json
@@ -1,6 +1,6 @@
 {
   "action_register": "登録",
-  "error_minimalBalanceAtNodeAddressIsRequired": "ガーディアンとして登録するには、「ノードアドレス」に最低1ETHの残高が必要です。",
+  "error_minimalBalanceAtNodeAddressIsRequired": "ガーディアンとして登録するには、「ノードアドレス」に最低{{balance}} {{name}}の残高が必要です。",
   "error_nodeAddressCannotBeTheSameAsGuardianAddress": "Orbsノードアドレスとガーディアンのアドレス{{guardianAddress}}は同じにすることはできません",
   "text_pleaseNote": "ご注意ください",
   "title_guardianRegistration": "ガーディアン登録",

--- a/src/translations/locales/ko/explanationsTexts.json
+++ b/src/translations/locales/ko/explanationsTexts.json
@@ -7,7 +7,7 @@
   "text_guardianAddress_usedByDelegatorsToDelegate": "델리게이터가 가디언에게 위임할 때 사용되는 주소입니다",
   "text_nodeAddress_doesNotHoldYourTokens": "ORBS 토큰을 이곳에 보관하지 마세요",
   "text_nodeAddress_holdsEthForAutomatedTransactionsGas": "노드에서 자동으로 트랜잭션을 할 수 있도록 가스비용 {{symbol}}을 넣어두세요",
-  "text_nodeAddress_minimalBalanceRequired": "등록시 최소 1 {{symbol}}이 들어있어야합니다",
+  "text_nodeAddress_minimalBalanceRequired": "등록시 최소 {{balance}} {{symbol}}이 들어있어야합니다",
   "text_nodeAddress_shouldBeDifferentFromGuardianAddress": "{{conceptNameGuardianAddress}}는 노드주소와 같이 사용할 수 없습니다",
   "text_nodeAddress_usedToSignBlocks": "오브스 블록체인에서 노드가 블록에 서명하는데 사용됩니다"
 }

--- a/src/translations/locales/ko/registerGuardianSection.json
+++ b/src/translations/locales/ko/registerGuardianSection.json
@@ -1,6 +1,6 @@
 {
   "action_register": "등록하기",
-  "error_minimalBalanceAtNodeAddressIsRequired": "가디언 등록을 위해 '노드 주소'에 최소 1 {{name}}이 들어있어야 합니다.",
+  "error_minimalBalanceAtNodeAddressIsRequired": "가디언 등록을 위해 '노드 주소'에 최소 {{balance}} {{name}}이 들어있어야 합니다.",
   "error_nodeAddressCannotBeTheSameAsGuardianAddress": "노드주소는 가디언 주소({{guardianAddress}})를 같이 사용할 수 없습니다",
   "text_pleaseNote": "주의사항: ",
   "title_guardianRegistration": "가디언 등록",


### PR DESCRIPTION
## Summary
- reduce the Ethereum guardian node balance requirement from 1 ETH to 0.1 ETH
- keep the Polygon node balance requirement at 1 native token
- compare balances in Wei to preserve exact fractional thresholds
- update Polygon native currency naming from MATIC to POL
- display the per-network minimum balance in English, Korean, and Japanese UI text

## Validation
- `tsc --noEmit`
- `npm run build`
- verified boundary behavior:
  - Ethereum: below 0.1 rejected, 0.1 accepted
  - Polygon: below 1 rejected, 1 accepted
- verified the local development server compiled successfully
